### PR TITLE
update diffusers to 0.32.0 to fix ImportError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pydantic==1.10.2
 loguru==0.6.0
 tqdm==4.64.1
 Pillow==9.2.0
-diffusers==0.4.2
+diffusers==0.32.2
 transformers
 scikit-image==0.19.3
 gradio


### PR DESCRIPTION
With diffusers==0.4.2 there's an error `ImportError: cannot import name 'cached_download' from 'huggingface_hub'` 